### PR TITLE
Add global Spotify now playing widget above nav

### DIFF
--- a/src/lib/components/NowPlayingWidget.svelte
+++ b/src/lib/components/NowPlayingWidget.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import type { SpotifySong } from '$lib/spotify/types';
+  import { onDestroy, onMount } from 'svelte';
+
+  let song = $state<SpotifySong | null>(null);
+
+  async function fetchNowPlaying() {
+    try {
+      const res = await fetch('/api/spotify/now-playing');
+      if (res.ok) {
+        song = await res.json();
+      }
+    } catch {
+      song = null;
+    }
+  }
+
+  let interval: ReturnType<typeof setInterval>;
+
+  onMount(() => {
+    fetchNowPlaying();
+    interval = setInterval(fetchNowPlaying, 30000);
+  });
+
+  onDestroy(() => {
+    clearInterval(interval);
+  });
+</script>
+
+{#if song?.playing}
+  <a
+    href={song.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="mb-4 flex w-full flex-row items-center gap-3 rounded-sm border border-aipink px-4 py-2 transition-all duration-200 hover:opacity-80"
+  >
+    <img src={song.coverUrl} alt={song.title} class="h-8 w-8 rounded-sm object-cover" />
+    <span class="font-mono text-sm text-aipink">♫</span>
+    <span class="font-mono text-sm font-bold text-aipink">{song.title}</span>
+    <span class="font-mono text-sm text-aipink">—</span>
+    <span class="font-mono text-sm text-aipink">{song.artists}</span>
+    <div class="ml-auto flex items-end gap-[3px]">
+      <span class="bar"></span>
+      <span class="bar" style="animation-delay: 0.2s"></span>
+      <span class="bar" style="animation-delay: 0.4s"></span>
+    </div>
+  </a>
+{/if}
+
+<style>
+  .bar {
+    display: inline-block;
+    width: 3px;
+    height: 12px;
+    background-color: #d423c6;
+    border-radius: 1px;
+    animation: bounce 0.8s ease-in-out infinite alternate;
+  }
+
+  @keyframes bounce {
+    from {
+      height: 4px;
+    }
+    to {
+      height: 14px;
+    }
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Nav from '$lib/components/Nav.svelte';
+  import NowPlayingWidget from '$lib/components/NowPlayingWidget.svelte';
   import { t } from '$lib/translations';
   import '../app.css';
 
@@ -11,6 +12,7 @@
 </svelte:head>
 
 <main class="max-w-screen flex min-h-screen flex-col items-center bg-aiblack p-12 max-[860px]:p-6">
+  <NowPlayingWidget />
   <Nav />
   {@render children()}
   <div

--- a/src/routes/api/spotify/now-playing/+server.ts
+++ b/src/routes/api/spotify/now-playing/+server.ts
@@ -1,0 +1,31 @@
+import {
+  SPOTIFY_REFRESH_TOKEN,
+  SPOTIFY_CLIENT_ID,
+  SPOTIFY_CLIENT_SECRET,
+} from '$env/static/private';
+import { getCurrentlyPlaying } from '$lib/spotify/currently.playing';
+import { json } from '@sveltejs/kit';
+
+export const GET = async () => {
+  const { access_token } = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: SPOTIFY_REFRESH_TOKEN,
+      redirect_uri: 'http://localhost:5173',
+      client_id: SPOTIFY_CLIENT_ID,
+      client_secret: SPOTIFY_CLIENT_SECRET,
+    }),
+  }).then((res) => res.json());
+
+  const song = await getCurrentlyPlaying(access_token);
+
+  return json(song, {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+};


### PR DESCRIPTION
Shows a minimal bar with album art, track name, and artist when
Spotify is actively playing. Polls /api/spotify/now-playing every
30s and disappears when nothing is playing.

https://claude.ai/code/session_018Kc2YjB9L2tTNm1pTahdui